### PR TITLE
Add drop impl's for PopplerPage and PopplerDocument

### DIFF
--- a/src/lib.rs
+++ b/src/lib.rs
@@ -2,5 +2,7 @@ mod document;
 mod page;
 mod util;
 
+pub use cairo::glib::Bytes;
+
 pub use document::PopplerDocument;
 pub use page::PopplerPage;

--- a/src/page.rs
+++ b/src/page.rs
@@ -50,4 +50,21 @@ impl PopplerPage {
             ptr => unsafe { Some(CStr::from_ptr(ptr).to_str().unwrap()) },
         }
     }
+
+    pub fn owned_text(&self) -> Option<String> {
+        match unsafe { sys_pg::poppler_page_get_text(self.0) } {
+            ptr if ptr.is_null() => None,
+            ptr => {
+                let text = unsafe { CStr::from_ptr(ptr).to_string_lossy().into_owned() };
+                unsafe { cairo::glib::ffi::g_free(ptr.cast()) };
+                Some(text)
+            }
+        }
+    }
+}
+
+impl std::ops::Drop for PopplerPage {
+    fn drop(&mut self) {
+        unsafe { cairo::glib::gobject_ffi::g_object_unref(self.0.cast()) }
+    }
 }

--- a/tests/test.rs
+++ b/tests/test.rs
@@ -1,5 +1,5 @@
 use cairo::{Context, Format, ImageSurface, PdfSurface};
-use poppler::{PopplerDocument, PopplerPage};
+use poppler::{Bytes, PopplerDocument, PopplerPage};
 use std::{fs::File, io::Read};
 
 #[test]
@@ -10,8 +10,8 @@ fn test1() -> Result<(), cairo::Error> {
 
     println!("Document has {} page(s)", num_pages);
 
-    let mut surface = PdfSurface::new(420.0, 595.0, "tests/output.pdf").unwrap();
-    let ctx = Context::new(&mut surface)?;
+    let surface = PdfSurface::new(420.0, 595.0, "tests/output.pdf").unwrap();
+    let ctx = Context::new(&surface)?;
 
     for (page_num, page) in doc.into_iter().enumerate() {
         let (w, h) = page.size();
@@ -59,8 +59,8 @@ fn test2_from_file() -> Result<(), cairo::Error> {
 
     assert_eq!(title, "This is a test PDF file");
 
-    let mut surface = ImageSurface::create(Format::ARgb32, w as i32, h as i32).unwrap();
-    let ctx = Context::new(&mut surface)?;
+    let surface = ImageSurface::create(Format::ARgb32, w as i32, h as i32).unwrap();
+    let ctx = Context::new(&surface)?;
 
     ctx.save()?;
     page.render(&ctx)?;
@@ -78,7 +78,8 @@ fn test2_from_data() {
     let mut file = File::open(path).unwrap();
     let mut data: Vec<u8> = Vec::new();
     file.read_to_end(&mut data).unwrap();
-    let doc: PopplerDocument = PopplerDocument::from_data(&mut data[..], "upw").unwrap();
+    let doc_bytes = Bytes::from(&data);
+    let doc: PopplerDocument = PopplerDocument::from_bytes(doc_bytes, "upw").unwrap();
     let num_pages = doc.n_pages();
     let title = doc.title().unwrap();
     let metadata = doc.metadata();
@@ -103,7 +104,7 @@ fn test2_from_data() {
 
 #[test]
 fn test3() {
-    let mut data = vec![];
+    let data = Bytes::from_static(&[]);
 
-    assert!(PopplerDocument::from_data(&mut data[..], "upw").is_err());
+    assert!(PopplerDocument::from_bytes(data, "upw").is_err());
 }


### PR DESCRIPTION
Hi! Thanks for updating poppler-rs!

I'm using poppler-rs to as a dependency on a web server I'm developing, and I noticed it had some memory leaks, so here's my attempt at solving them.

- I mainly use `PopplerPage::text()`, and that function returns a `Cstr` that should be freed, so I made `PopplerPage::owned_text()` that copies that `Cstr` into a `String` and frees the original pointer.
- I'm also using `PopplerDocument::from_bytes` so I noticed the underlying `glib::Bytes` had an extra ref count, so I changed the ownership type.
- I ran rustfmt and updated the tests to use `PopplerDocument::from_bytes` instead of `PopplerDocument::from_data`.